### PR TITLE
Update cmake-single-platform.yml

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -2,7 +2,8 @@ name: Build LogUtil (Windows + macOS)
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+    - "**"  # all branches
   pull_request:
     branches: [ "main" ]
   workflow_dispatch:


### PR DESCRIPTION
This PR updates the GitHub Actions workflow trigger to run on all branches, not just main.

- `push` now matches `"**"` to trigger CI on any branch
- `pull_request` remains targeting `main` to validate incoming PRs
- Useful for early validation before PR creation

Tested by pushing to feature branches and confirming CI is triggered as expected.